### PR TITLE
allow other mods to detect this mod

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,5 +1,5 @@
 local armor_intalled = minetest.global_exists("armor")
-local clothes = {}
+clothes = {}
 local num_faces = 0
 local num_skins = 0
 local num_hairs = 0


### PR DESCRIPTION
In order for other mods to be able to detect the mod and adapt their behaviour (possibly also in order to work around the currently open issue [1]), it would be preferable to have a globally accessible "clothes" symbol. This can be checked for using minetest.global_exists.

[1] https://github.com/MrRar/clothes/issues/1